### PR TITLE
Fix Testnet Badge

### DIFF
--- a/src/components/testnet-badge/testnet-badge.tsx
+++ b/src/components/testnet-badge/testnet-badge.tsx
@@ -10,7 +10,7 @@ import { getSelectedBlockchain } from '../../redux/wallets/selectors';
 import { IReduxState } from '../../redux/state';
 import { getNetworkName } from '../../redux/preferences/selectors';
 import { translate } from '../../core/i18n';
-import { getBlockchain } from '../../core/blockchain/blockchain-factory';
+import { Capitalize } from '../../core/utils/format-string';
 
 export interface IReduxProps {
     blockchain: Blockchain;
@@ -23,35 +23,29 @@ const mapStateToProps = (state: IReduxState) => {
 
     return {
         blockchain,
-        networkName: getNetworkName(state, blockchain),
+        networkName: blockchain && getNetworkName(state, blockchain),
         testNet: state.preferences.testNet
     };
 };
 
-export class TestnetBadgeComponent extends React.Component<
-    IReduxProps & IThemeProps<ReturnType<typeof stylesProvider>>
-> {
-    public render() {
-        const styles = this.props.styles;
-        const config = getBlockchain(this.props.blockchain).config;
-        const blockchain = config.tokens[config.coin].name;
-
-        if (this.props.testNet) {
-            return (
-                <View style={styles.container}>
-                    <Text style={styles.text}>
-                        {translate('App.labels.youAreOn', {
-                            blockchain,
-                            networkName: this.props.networkName
-                        })}
-                    </Text>
-                </View>
-            );
-        } else {
-            return <View />;
-        }
+export const TestnetBadgeComponent = (
+    props: IReduxProps & IThemeProps<ReturnType<typeof stylesProvider>>
+) => {
+    if (props.testNet) {
+        return (
+            <View style={props.styles.container}>
+                <Text style={props.styles.text}>
+                    {translate('App.labels.youAreOn', {
+                        blockchain: Capitalize(props.blockchain),
+                        networkName: props.networkName
+                    })}
+                </Text>
+            </View>
+        );
+    } else {
+        return <View />;
     }
-}
+};
 
 export const TestnetBadge = smartConnect(TestnetBadgeComponent, [
     connect(mapStateToProps, null),

--- a/src/core/utils/format-string.ts
+++ b/src/core/utils/format-string.ts
@@ -1,0 +1,3 @@
+export const Capitalize = (str: string) => {
+    return str.charAt(0).toUpperCase() + str.slice(1).toLocaleLowerCase();
+};


### PR DESCRIPTION
- convert to hooks
- app crashed when there were no wallets (because of `getBlockchain(blockchain)` and `blockchain` was empty string)