### PR TITLE
Password Modal - Fix Face ID auth

### DIFF
--- a/src/components/password-modal/components/password-pin/password-pin.tsx
+++ b/src/components/password-modal/components/password-pin/password-pin.tsx
@@ -36,6 +36,7 @@ export interface IExternalProps {
     enableBiometryAuth: boolean;
     allowBackButton: boolean;
     onBackButtonTap: () => void;
+    isMoonletDisabled: boolean;
 }
 
 interface IState {
@@ -64,7 +65,7 @@ export class PasswordPinComponent extends React.Component<
         };
         this.shakeAnimation = new Animated.Value(0);
 
-        if (props.enableBiometryAuth === true) {
+        if (props.enableBiometryAuth === true && props.isMoonletDisabled === false) {
             this.biometryAuth();
         }
     }
@@ -219,12 +220,10 @@ export class PasswordPinComponent extends React.Component<
             .then(success => {
                 if (success) {
                     this.props.onBiometryLogin(true);
-                } else {
-                    this.props.onBiometryLogin(false);
                 }
             })
             .catch(error => {
-                this.props.onBiometryLogin(false);
+                //
             });
     }
 

--- a/src/components/password-modal/password-modal-component.tsx
+++ b/src/components/password-modal/password-modal-component.tsx
@@ -408,7 +408,11 @@ export class PasswordModalComponent extends React.Component<
     }
 
     private isMoonletDisabled(): boolean {
-        return this.props.blockUntil && new Date(this.props.blockUntil) > this.getCurrentDate();
+        if (this.props.blockUntil) {
+            return this.props.blockUntil && new Date(this.props.blockUntil) > this.getCurrentDate();
+        } else {
+            return false;
+        }
     }
 
     public render() {
@@ -430,8 +434,6 @@ export class PasswordModalComponent extends React.Component<
                         onBiometryLogin={(success: boolean) => {
                             if (success === true) {
                                 this.updateState({ biometryAuthResult: true });
-                            } else {
-                                this.updateState({ biometryAuthResult: false });
                             }
                         }}
                         errorMessage={this.state.errorMessage}
@@ -439,6 +441,7 @@ export class PasswordModalComponent extends React.Component<
                         enableBiometryAuth={this.state.enableBiometryAuth}
                         allowBackButton={this.state.allowBackButton}
                         onBackButtonTap={() => this.onBackButtonTap()}
+                        isMoonletDisabled={this.isMoonletDisabled()}
                     />
                 )}
 


### PR DESCRIPTION
Fixed: 

- when using face id / touch id, failed logins shouldn't be counted, the OS is already doing that. If user fails to login using biometrics the OS will block biometric login after a few tries.

- if a user has biometric login active (faceid), and blocks the application, on each app start a new failed login will be counted in background